### PR TITLE
refactor!: rename `kafka-schema-registry` to `schema-registry` as the provider is kafka agnostic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DOCKER_COMPOSE_RUN := docker compose run --rm
 VERSION ?= 1.0.0
-PROVIDER_NAME = terraform-provider-kafka-schema-registry
+PROVIDER_NAME = terraform-provider-schema-registry
 ARCHS = amd64 arm64 arm 386
 PLATFORMS = linux darwin windows freebsd
 UNSUPPORTED_COMBOS = darwin/arm darwin/386
@@ -62,7 +62,7 @@ docs: ## Generate provider documentation for the Terraform registry
 # Add double hash '##' plus the help text you would like to display for "make help" against that command
 help: ### Show help for documented commands
 	@echo "-------------------------------"
-	@echo "cultureamp/terraform-provider-kafka-schema-registry"
+	@echo "cultureamp/terraform-provider-schema-registry"
 	@echo "-------------------------------"
 	@grep --no-filename -E '^[-a-zA-Z_:]+.*[^#]## .*$$' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-28s\033[0m %s\n", $$1, $$2}' | \

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
     <img src="https://www.svgrepo.com/show/448253/terraform.svg" alt="Terraform logo" title="Terraform" align="left" height="70" />
 </a>
 
-# Terraform Provider for Kafka Schema Registry
+# Terraform Provider for Schema Registry
 
 This provider is built using the [Terraform Plugin Framework](https://github.com/hashicorp/terraform-plugin-framework).
 
@@ -38,7 +38,7 @@ If you're building the provider, follow the instructions to [install it as a plu
 terraform {
   required_providers {
     schemaregistry = {
-      source = "cultureamp/kafka-schema-registry"
+      source = "cultureamp/schema-registry"
       version = "1.0.0"
     }
   }

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,9 @@
 ---
 layout: "schema registry"
-page_title: "Provider: Kafka Schema Registry"
+page_title: "Provider: Schema Registry"
 sidebar_current: "docs-schema registry-index"
 description: |-
-  The Kafka Schema Registry provider to interact with schemas
+  The Schema Registry provider to interact with schemas
 ---
 
 # Schema Registry Provider

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/cultureamp/terraform-provider-kafka-schema-registry
+module github.com/cultureamp/terraform-provider-schema-registry
 
 go 1.21
 
@@ -136,5 +136,5 @@ require (
 )
 
 // replace (
-// 	github.com/cultureamp/terraform-provider-kafka-schema-registry/internal/provider => ./internal/provider
+// 	github.com/cultureamp/terraform-provider-schema-registry/internal/provider => ./internal/provider
 // )

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 	"log"
 
-	"github.com/cultureamp/terraform-provider-kafka-schema-registry/internal/provider"
+	"github.com/cultureamp/terraform-provider-schema-registry/internal/provider"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 )
 
@@ -35,7 +35,7 @@ func main() {
 	flag.Parse()
 
 	opts := providerserver.ServeOpts{
-		Address: "github.com/cultureamp/terraform-provider-kafka-schema-registry", // This can be any string, it's just an identifier
+		Address: "github.com/cultureamp/terraform-provider-schema-registry", // This can be any string, it's just an identifier
 		Debug:   debug,
 	}
 


### PR DESCRIPTION
### Description
Renaming the references to Kafka Schema Registry or `kafka-schema-registry` to Schema Registry and `schema-registry` as the inclusion of `Kafka` is superfluous and this provider could be used in situations without Kafka. 

This will also be tied to a renaming of this repository and a republishing of the provider under the correct name

### Relations

N/A

### References

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
